### PR TITLE
Fix mapping and nominal treatment for issue #6

### DIFF
--- a/pipefitter/backends/sas/estimator/base.py
+++ b/pipefitter/backends/sas/estimator/base.py
@@ -30,11 +30,11 @@ import re
 DTREE_MAP = {
     'max_branches': 'proc_option_maxbranch',
     'max_depth'   : 'proc_option_maxdepth',
-    'leaf_size'   : 'minleafsize',
+    'leaf_size'   : 'proc_option_minleafsize',
     'inputs'      : 'input',
     'n_bins'      : 'proc_option_intervalbins',
     'prune'       : 'prune',
-    'alpha'       : 'alpha',
+    # 'alpha'       : 'alpha', # Alpha is not a general option for HPSPLIT
     'nominals'    : 'nominals'
 }
 
@@ -98,6 +98,8 @@ class EstimatorMixIn(object):
 
         '''
         out = {}
+        # add caller key so SASPy knows to deal with nominals in all cases
+        out['caller'] = 'pipefitter'
         procoptsDict = {}
 
         if est == 'RF':


### PR DESCRIPTION
The PR also required changes in SASPy which were pushed [here](https://github.com/sassoftware/saspy/commit/44e420632b6da6eb859f3019f87a65fa70df3efe).

This issue will remain until a new SASPy release is complete (or you build SASPy from source).

The simple issue was the treatment of the `minleafsize` and `alpha`.
The more complex issue was the treatment of the nominal key. SASPy, before the change, would only consider the `nominal` key if the method required a `model` statement. The fix was to add a caller keyword to evaluate each call from Pipefitter regardless of the required statements in SASPy. 